### PR TITLE
github/workflows/main: install setuptools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - run: pip install pre-commit-mirror-maker
+      - run: pip install pre-commit-mirror-maker setuptools
 
       - name: set git config
         run: |


### PR DESCRIPTION
This should fix pre-commit-mirror-maker on Python 3.12.